### PR TITLE
Enhance PostgreSQL backup/restore UI & argument handling

### DIFF
--- a/Main.Designer.cs
+++ b/Main.Designer.cs
@@ -28,7 +28,7 @@
         /// </summary>
         private void InitializeComponent()
         {
-            AntdUI.Tabs.StyleLine styleLine2 = new AntdUI.Tabs.StyleLine();
+            AntdUI.Tabs.StyleLine styleLine1 = new AntdUI.Tabs.StyleLine();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Main));
             pageHeader = new AntdUI.PageHeader();
             colorTheme = new AntdUI.ColorPicker();
@@ -48,6 +48,8 @@
             BtnRetrieveDatabaseNames = new AntdUI.Button();
             lblBackupdatabaseNames = new AntdUI.Label();
             BtnBackup = new AntdUI.Button();
+            SqlPage = new AntdUI.TabPage();
+            PanelSqlPageBase = new AntdUI.Panel();
             RestorePage = new AntdUI.TabPage();
             PnlRestorePage = new AntdUI.Panel();
             BtnRestore = new AntdUI.Button();
@@ -87,8 +89,6 @@
             InpPgBinPath = new AntdUI.Input();
             BtnBrowsePostgrePath = new AntdUI.Button();
             lblPgBinPath = new AntdUI.Label();
-            SqlPage = new AntdUI.TabPage();
-            PanelSqlPageBase = new AntdUI.Panel();
             pageHeader.SuspendLayout();
             pnlMain.SuspendLayout();
             panel1.SuspendLayout();
@@ -98,6 +98,7 @@
             pnlBaseBackupPage.SuspendLayout();
             PnlBackupSaveTo.SuspendLayout();
             PnlBackupListDatabase.SuspendLayout();
+            SqlPage.SuspendLayout();
             RestorePage.SuspendLayout();
             PnlRestorePage.SuspendLayout();
             PnlBackupFileToRestore.SuspendLayout();
@@ -112,7 +113,6 @@
             pnlDbPort.SuspendLayout();
             PnlDbname.SuspendLayout();
             pnlPgBinPath.SuspendLayout();
-            SqlPage.SuspendLayout();
             SuspendLayout();
             // 
             // pageHeader
@@ -207,7 +207,7 @@
             tabs.Pages.Add(RestorePage);
             tabs.Pages.Add(SettingPage);
             tabs.Size = new System.Drawing.Size(821, 477);
-            tabs.Style = styleLine2;
+            tabs.Style = styleLine1;
             tabs.TabIndex = 0;
             tabs.Text = "tabs1";
             // 
@@ -343,6 +343,24 @@
             BtnBackup.Text = "BACKUP";
             BtnBackup.Type = AntdUI.TTypeMini.Primary;
             BtnBackup.Click += BtnBackup_Click;
+            // 
+            // SqlPage
+            // 
+            SqlPage.Controls.Add(PanelSqlPageBase);
+            SqlPage.Location = new System.Drawing.Point(4, 29);
+            SqlPage.Name = "SqlPage";
+            SqlPage.Size = new System.Drawing.Size(813, 445);
+            SqlPage.TabIndex = 0;
+            SqlPage.Text = "SQL";
+            // 
+            // PanelSqlPageBase
+            // 
+            PanelSqlPageBase.Dock = System.Windows.Forms.DockStyle.Fill;
+            PanelSqlPageBase.Location = new System.Drawing.Point(0, 0);
+            PanelSqlPageBase.Name = "PanelSqlPageBase";
+            PanelSqlPageBase.Size = new System.Drawing.Size(813, 445);
+            PanelSqlPageBase.TabIndex = 0;
+            PanelSqlPageBase.Text = "panel4";
             // 
             // RestorePage
             // 
@@ -817,24 +835,6 @@
             lblPgBinPath.Text = "POSTGRESQL BIN FOLDER";
             lblPgBinPath.TextAlign = System.Drawing.ContentAlignment.MiddleCenter;
             // 
-            // SqlPage
-            // 
-            SqlPage.Controls.Add(PanelSqlPageBase);
-            SqlPage.Location = new System.Drawing.Point(4, 29);
-            SqlPage.Name = "SqlPage";
-            SqlPage.Size = new System.Drawing.Size(813, 445);
-            SqlPage.TabIndex = 0;
-            SqlPage.Text = "SQL";
-            // 
-            // PanelSqlPageBase
-            // 
-            PanelSqlPageBase.Dock = System.Windows.Forms.DockStyle.Fill;
-            PanelSqlPageBase.Location = new System.Drawing.Point(0, 0);
-            PanelSqlPageBase.Name = "PanelSqlPageBase";
-            PanelSqlPageBase.Size = new System.Drawing.Size(813, 445);
-            PanelSqlPageBase.TabIndex = 0;
-            PanelSqlPageBase.Text = "panel4";
-            // 
             // Main
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
@@ -859,6 +859,7 @@
             pnlBaseBackupPage.ResumeLayout(false);
             PnlBackupSaveTo.ResumeLayout(false);
             PnlBackupListDatabase.ResumeLayout(false);
+            SqlPage.ResumeLayout(false);
             RestorePage.ResumeLayout(false);
             PnlRestorePage.ResumeLayout(false);
             PnlBackupFileToRestore.ResumeLayout(false);
@@ -873,7 +874,6 @@
             pnlDbPort.ResumeLayout(false);
             PnlDbname.ResumeLayout(false);
             pnlPgBinPath.ResumeLayout(false);
-            SqlPage.ResumeLayout(false);
             ResumeLayout(false);
 
         }

--- a/Main.cs
+++ b/Main.cs
@@ -44,6 +44,8 @@ public partial class Main : Window
 
     private async void BtnBackup_Click(object sender, EventArgs e)
     {
+        BtnBackup.Enabled = false;
+
         var context = AppConfig.PostgresqlConnectionContext;
         var pgDumpPath = InpPgBinPath.Text;
 
@@ -54,15 +56,20 @@ public partial class Main : Window
 
         var backup = new BackupDatabase(context);
         var outputPath = InpBackupSaveTo.Text;
+        var dbName = SelectDbNameToBackup.Text;
 
         try
         {
-            await backup.BackupAsync(pgDumpPath, outputPath);
+            await backup.BackupAsync(pgDumpPath, dbName, outputPath);
             Message.success(this, $"Backup completed successfully. Output: {outputPath}");
         }
         catch (Exception)
         {
             Message.error(this, $"Backup failed");
+        }
+        finally
+        {
+            BtnBackup.Enabled = true;
         }
     }
 
@@ -166,7 +173,7 @@ public partial class Main : Window
         {
             BtnRetrieveDatabaseNames.Enabled = false;
 
-            await RetrieveDatabaseAndSetToControl(dbService, DdDatabases);
+            await RetrieveDatabaseAndSetToControl(dbService, SelectDbNameToBackup);
         }
         catch (Exception err)
         {
@@ -265,6 +272,8 @@ public partial class Main : Window
     {
         try
         {
+            BtnRestore.Enabled = false;
+
             using var cts = new CancellationTokenSource();
             var dbName = InpDatabaseTorestore.Text;
 
@@ -294,10 +303,16 @@ public partial class Main : Window
 
             var restore = new RestoreDatabase(appConfig.PostgresqlConnectionContext);
             await restore.RestoreAsync(InpPgBinPath.Text, InptBackupFileToRestore.Text, dbName, cts.Token);
+
+            Message.info(this, $"Database \"{dbName}\" successfully restored.");
         }
         catch (Exception err)
         {
             Message.error(this, $"Restore Database gagal. {Environment.NewLine}{err.Message}");
+        }
+        finally
+        {
+            BtnRestore.Enabled = true;
         }
     }
 

--- a/Pages/SqlPage.cs
+++ b/Pages/SqlPage.cs
@@ -88,7 +88,7 @@ public partial class SqlPage : UserControl
                 Port = appConfig.PostgresqlConnectionContext.Port,
             };
 
-            var sqlQuery = new PsqlQuery(context);
+            var sqlQuery = new PsqlQuery(context, PsqlQuery.PsqlOptions.Default);
 
             if (sqlStringTooLong
                 && File.Exists(InpSqlFile.Text))
@@ -104,8 +104,8 @@ public partial class SqlPage : UserControl
                     ? input1.Text
                     : input1.SelectedText);
 
-            await sqlQuery.ExecuteSqlFileAsync(appConfig.PostgresqlBinPath, SQL_TEMP_FILE_NAME, cts.Token);
-            Message.info(ParentForm, "Query successfully executed");
+            var result = await sqlQuery.ExecuteSqlFileAsync(appConfig.PostgresqlBinPath, SQL_TEMP_FILE_NAME, cts.Token);
+            Message.info(ParentForm, $"Query successfully executed{Environment.NewLine}{result}");
         }
         catch (Exception err)
         {

--- a/Services/BackupDatabase.cs
+++ b/Services/BackupDatabase.cs
@@ -15,12 +15,12 @@ public sealed class BackupDatabase
         this.context = context;
     }
 
-    public async Task BackupAsync(string pgDumpPath, string outputPath, CancellationToken token = default)
+    public async Task BackupAsync(string pgDumpPath, string dbName, string outputPath, CancellationToken token = default)
     {
         var psi = new ProcessStartInfo
         {
             FileName = Path.Combine(pgDumpPath, "pg_dump.exe"),
-            Arguments = $"-h {context.Host} -p {context.Port} -U {context.DatabaseUser} -Fc -b -f \"{outputPath}\" \"{context.DatabaseName}\"",
+            Arguments = $"-h {context.Host} -p {context.Port} -U {context.DatabaseUser} -Fc -b -f \"{outputPath}\" \"{dbName}\"",
         };
         psi.EnvironmentVariables["PGPASSWORD"] = context.DatabasePassword;
 

--- a/Services/DbService.cs
+++ b/Services/DbService.cs
@@ -10,7 +10,7 @@ public sealed class DbService(string binPath, PostgresqlConnectionContext contex
 {
     public async Task<IEnumerable<string>> GetAllDatabaseNameAsync()
     {
-        var psqlQuery = new PsqlQuery(context);
+        var psqlQuery = new PsqlQuery(context, new PsqlQuery.PsqlOptions { ShowColumnName = false });
         var query = PsqlQuery.QueryGetAllDatabaseName;
 
         var result = await psqlQuery.ExecuteQueryAsync(binPath, query);

--- a/Services/PsqlArgumentBuilder.cs
+++ b/Services/PsqlArgumentBuilder.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections.Generic;
+using static PostgresqlUtility.Services.PsqlQuery;
+
+namespace PostgresqlUtility.Services;
+
+public sealed class PsqlArgumentsBuilder
+{
+    private PsqlOptions _options = PsqlOptions.Default;
+    private string _host;
+    private int? _port;
+    private string _user;
+    private string _database;
+    private string _command; // inline SQL (-c)
+    private string _file;    // SQL file path (-f)
+
+    private static string Quote(string s) =>
+        (s ?? "").IndexOf(' ') >= 0
+            ? $"\"{s.Replace("\"", "\\\"")}\""
+            : s;
+
+    public static PsqlArgumentsBuilder Create() => new PsqlArgumentsBuilder();
+
+    public PsqlArgumentsBuilder WithOptions(PsqlOptions options)
+    {
+        _options = options ?? PsqlOptions.Default;
+        return this;
+    }
+
+    public PsqlArgumentsBuilder WithHost(string host)
+    {
+        _host = host;
+        return this;
+    }
+
+    public PsqlArgumentsBuilder WithPort(int port)
+    {
+        _port = port;
+        return this;
+    }
+
+    public PsqlArgumentsBuilder WithUser(string user)
+    {
+        _user = user;
+        return this;
+    }
+
+    public PsqlArgumentsBuilder WithDatabase(string database)
+    {
+        _database = database;
+        return this;
+    }
+
+    /// <summary>
+    /// Supply an inline SQL command via -c. Mutually exclusive with WithFile().
+    /// </summary>
+    public PsqlArgumentsBuilder WithCommand(string sql)
+    {
+        if (string.IsNullOrWhiteSpace(sql))
+            throw new ArgumentException("SQL command cannot be null or empty.", nameof(sql));
+
+        // Trim whitespace and ensure trailing semicolon
+        var trimmed = sql.TrimEnd();
+        if (!trimmed.EndsWith(';'))
+        {
+            trimmed += ";";
+        }
+
+        _command = trimmed;
+        _file = null; // clear any previously set file
+        return this;
+    }
+
+    /// <summary>
+    /// Supply a path to a SQL script file via -f. Mutually exclusive with WithCommand().
+    /// </summary>
+    public PsqlArgumentsBuilder WithFile(string pathToFile)
+    {
+        _file = pathToFile;
+        _command = null; // clear command if previously set
+        return this;
+    }
+
+    public string Build()
+    {
+        // Validate that exactly one of command/file is set:
+        if (string.IsNullOrEmpty(_command) && string.IsNullOrEmpty(_file))
+            throw new InvalidOperationException("Either an inline SQL command or a SQL file path must be specified.");
+        if (!string.IsNullOrEmpty(_command) && !string.IsNullOrEmpty(_file))
+            throw new InvalidOperationException("Cannot specify both inline SQL command and SQL file path.");
+
+        var parts = new List<string>();
+
+        if (!string.IsNullOrEmpty(_host))
+            parts.Add($"-h {Quote(_host)}");
+
+        if (_port.HasValue)
+            parts.Add($"-p {_port.Value}");
+
+        if (!string.IsNullOrEmpty(_user))
+            parts.Add($"-U {Quote(_user)}");
+
+        if (!string.IsNullOrEmpty(_database))
+            parts.Add($"-d {Quote(_database)}");
+
+        if (!_options.ShowColumnName)
+            parts.Add("-t");
+
+        // exactly one of these will run:
+        if (!string.IsNullOrEmpty(_command))
+            parts.Add($"-c {Quote(_command)}");
+        else
+            parts.Add($"-f {Quote(_file)}");
+
+        return string.Join(" ", parts);
+    }
+}

--- a/Services/PsqlQuery.cs
+++ b/Services/PsqlQuery.cs
@@ -9,19 +9,42 @@ namespace PostgresqlUtility.Services;
 
 public sealed class PsqlQuery
 {
-    private readonly PostgresqlConnectionContext context;
+    public sealed class PsqlOptions
+    {
+        public bool ShowColumnName { get; set; } = true;
 
-    public PsqlQuery(PostgresqlConnectionContext context)
+        public static PsqlOptions Default => new();
+    }
+
+    private readonly PostgresqlConnectionContext context;
+    private readonly PsqlOptions options;
+
+    public PsqlQuery(PostgresqlConnectionContext context) : this(context, PsqlOptions.Default)
+    {
+
+    }
+
+    public PsqlQuery(PostgresqlConnectionContext context, PsqlOptions options)
     {
         this.context = context;
+        this.options = options;
     }
 
     public async Task<string> ExecuteQueryAsync(string pgBinPath, string query, CancellationToken token = default)
     {
+        var inlineArgs = PsqlArgumentsBuilder.Create()
+            .WithOptions(options) // tuples-only
+            .WithHost(context.Host)
+            .WithPort(context.Port)
+            .WithUser(context.DatabaseUser)
+            .WithDatabase(context.DatabaseName)
+            .WithCommand(query)
+            .Build();
+
         var psi = new ProcessStartInfo
         {
             FileName = Path.Combine(pgBinPath, "psql.exe"),
-            Arguments = $"-h {context.Host} -p {context.Port} -U {context.DatabaseUser} -d {context.DatabaseName} -t -c \"{query}\"",
+            Arguments = inlineArgs,
         };
         psi.EnvironmentVariables["PGPASSWORD"] = context.DatabasePassword;
 
@@ -36,10 +59,19 @@ public sealed class PsqlQuery
 
     public async Task<string> ExecuteSqlFileAsync(string pgBinPath, string file, CancellationToken token)
     {
+        var fileArgs = PsqlArgumentsBuilder.Create()
+            .WithOptions(options)
+            .WithHost(context.Host)
+            .WithPort(context.Port)
+            .WithUser(context.DatabaseUser)
+            .WithDatabase(context.DatabaseName)
+            .WithFile(file)
+            .Build();
+
         var psi = new ProcessStartInfo
         {
             FileName = Path.Combine(pgBinPath, "psql.exe"),
-            Arguments = $"-h {context.Host} -p {context.Port} -U {context.DatabaseUser} -d {context.DatabaseName} -t -f \"{file}\"",
+            Arguments = fileArgs,
         };
         psi.EnvironmentVariables["PGPASSWORD"] = context.DatabasePassword;
 


### PR DESCRIPTION
- Fix backup operation to use the selected database rather than the default
- Improve UI functionality:
  - Add SqlPage and PanelSqlPageBase components
  - Update BtnBackup_Click to accept a database-name parameter
  - Manage button states in BtnRestore_Click during long-running operations
- Refactor PsqlQuery to use PsqlArgumentsBuilder for safer, more maintainable CLI argument handling